### PR TITLE
Fix/user feedback

### DIFF
--- a/slid-todo/__tests__/goals/[goalId]/components/goal-list-content.test.tsx
+++ b/slid-todo/__tests__/goals/[goalId]/components/goal-list-content.test.tsx
@@ -1,0 +1,164 @@
+import GoalListContent from "@/app/(routes)/goals/[goalId]/components/goal-list-content";
+import { renderWithProviders } from "../../../data/test-utils";
+import { expect } from "@jest/globals";
+import { TodoListContent } from "@/app/(routes)/(todos)/todos/components/todo-list-content";
+import { useGoalTodosInfinite } from "@/hooks/goals/use-goal-todos";
+import { useFormModal } from "@/stores/use-form-modal-store";
+import { useCreateTodo } from "@/hooks/todo/use-todo-actions";
+import { userEvent } from "@testing-library/user-event";
+import { act, fireEvent, getByText, render, screen } from "@testing-library/react";
+import { createMockTodoData, mockTodoData, mockTodoList } from "../../../data/todo";
+
+jest.mock("@/hooks/goals/use-goal-todos", () => ({
+  useGoalTodosInfinite: () => ({
+    isLoading: false,
+  }),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+  useParams: () => ({
+    goalId: "1",
+  }),
+}));
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => ({ ref: jest.fn(), inView: false }),
+}));
+
+const mockOnOpen = jest.fn();
+jest.mock("@/stores/use-form-modal-store", () => ({
+  useFormModal: () => ({
+    onOpen: mockOnOpen,
+  }),
+}));
+
+jest.mock("@/hooks/todo/use-todo-actions", () => ({
+  useCreateTodo: () => ({
+    mutate: jest.fn(),
+  }),
+  useUpdateTodoDone: () => ({
+    mutate: jest.fn(),
+  }),
+  useDeleteTodo: () => ({
+    mutate: jest.fn(),
+  }),
+  useUpdateTodo: () => ({
+    mutate: jest.fn(),
+  }),
+}));
+
+describe("Goal List Content", () => {
+  it("로딩 중일 때 null을 반환한다", () => {
+    jest
+      .spyOn(require("@/hooks/goals/use-goal-todos"), "useGoalTodosInfinite")
+      .mockImplementation(() => ({
+        isLoading: true,
+      }));
+
+    const { container } = render(<GoalListContent />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("데이터 로딩", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("Todo 목록을 올바르게 렌더링한다", () => {
+      const mockTodos = mockTodoList.filter((todo) => !todo.done);
+      const mockData = createMockTodoData(mockTodos);
+
+      jest
+        .spyOn(require("@/hooks/goals/use-goal-todos"), "useGoalTodosInfinite")
+        .mockImplementation((_, isDone = false) => ({
+          isLoading: false,
+          isFetchingNextPage: false,
+          data: isDone ? createMockTodoData([]) : mockData,
+          hasNextPage: false,
+          fetchNextPage: jest.fn(),
+        }));
+
+      const { getByText } = renderWithProviders(<GoalListContent />);
+
+      // Todo 섹션 확인
+      expect(getByText("Todo")).toBeInTheDocument();
+
+      mockTodos.forEach((todo) => {
+        expect(getByText(todo.title)).toBeInTheDocument();
+      });
+    });
+
+    it("Done 목록을 올바르게 렌더링한다", () => {
+      const mockDoneTodos = mockTodoList.filter((todo) => todo.done);
+      const mockData = createMockTodoData(mockDoneTodos);
+
+      jest
+        .spyOn(require("@/hooks/goals/use-goal-todos"), "useGoalTodosInfinite")
+        .mockImplementation((_, isDone = false) => ({
+          isLoading: false,
+          isFetchingNextPage: false,
+          data: isDone ? mockData : createMockTodoData([]),
+          hasNextPage: false,
+          fetchNextPage: jest.fn(),
+        }));
+
+      const { getByText } = renderWithProviders(<GoalListContent />);
+
+      expect(getByText("Done")).toBeInTheDocument();
+
+      mockDoneTodos.forEach((todo) => {
+        expect(getByText(todo.title)).toBeInTheDocument();
+      });
+    });
+  });
+  describe("할 일 추가", () => {
+    const mockCreateTodo = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest
+        .spyOn(require("@/hooks/todo/use-todo-actions"), "useCreateTodo")
+        .mockImplementation(() => ({
+          mutate: mockCreateTodo,
+        }));
+    });
+
+    it("버튼 클릭 시 모달이 올바른 파라미터로 열린다", () => {
+      const { getByRole } = renderWithProviders(<GoalListContent />);
+
+      const addButton = getByRole("button", { name: /할 일 추가/i });
+      fireEvent.click(addButton);
+
+      expect(mockOnOpen).toHaveBeenCalledWith({
+        type: "todo",
+        mode: "create",
+        defaultValues: {
+          id: 0,
+          title: "",
+          goal: {
+            id: 1,
+            title: "",
+          },
+        },
+        onSubmit: expect.any(Function),
+      });
+    });
+
+    it("모달 onSubmit 호출 시 createTodo가 호출된다", () => {
+      const { getByRole } = renderWithProviders(<GoalListContent />);
+
+      const addButton = getByRole("button", { name: /할 일 추가/i });
+      fireEvent.click(addButton);
+
+      const modalConfig = mockOnOpen.mock.calls[0][0];
+
+      const testData = { title: "새로운 할일" };
+      modalConfig.onSubmit(testData);
+
+      expect(mockCreateTodo).toHaveBeenCalledWith(testData);
+    });
+  });
+});

--- a/slid-todo/src/app/(routes)/dashboard/components/goal-todo-block/goal-todo-container.tsx
+++ b/slid-todo/src/app/(routes)/dashboard/components/goal-todo-block/goal-todo-container.tsx
@@ -34,11 +34,10 @@ const GoalToDoContainer = () => {
 
   const goals = data?.pages.flatMap((page) => page.goals) || [];
 
-  // ScrollArea 밖으로 EmptyState 이동
   if (goals.length === 0) {
     return (
       <div
-        className="w-full h-[calc(100vh-340px)] flex items-center justify-center"
+        className="w-full flex-1 min-h-[300px] flex items-center justify-center"
         data-cy="no-goals-message"
       >
         <EmptyState message="등록한 목표가 없어요" />

--- a/slid-todo/src/app/(routes)/dashboard/components/goal-todo-block/goal-todo.tsx
+++ b/slid-todo/src/app/(routes)/dashboard/components/goal-todo-block/goal-todo.tsx
@@ -4,7 +4,7 @@ import GoalToDoContainer from "./goal-todo-container";
 
 const GoalToDo = () => {
   return (
-    <div className="bg-card text-card-foreground w-full h-[calc(100vh-340px)] rounded-2xl flex flex-col p-4 transition-colors">
+    <div className="bg-card text-card-foreground w-full rounded-2xl flex flex-col p-4 transition-colors">
       <div className="flex gap-2 px-4 py-2 items-center">
         <Goal className="w-10 h-10 rounded-xl" />
         <h2 className="text-lg font-semibold text-foreground">목표 별 할 일</h2>

--- a/slid-todo/src/app/(routes)/dashboard/layout.tsx
+++ b/slid-todo/src/app/(routes)/dashboard/layout.tsx
@@ -4,8 +4,10 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 export default function DashBoardLayout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider>
-      <AppSidebar />
-      <div className="w-full rounded-lg bg-[#F1F5F9] dark:bg-black">{children}</div>
+      <div className="w-full flex overflow-x-hidden">
+        <AppSidebar />
+        <div className="w-full min-w-0 rounded-lg bg-[#F1F5F9] dark:bg-black">{children}</div>
+      </div>
     </SidebarProvider>
   );
 }

--- a/slid-todo/src/app/(routes)/dashboard/page.tsx
+++ b/slid-todo/src/app/(routes)/dashboard/page.tsx
@@ -23,10 +23,10 @@ const DashBoard = () => {
   }
 
   return (
-    <div className="container px-4 py-6 my-10 md:my-0">
-      <div className="rounded-2xl w-full mx-auto h-full lg:mx-16 flex flex-col gap-4">
+    <div className="container py-6 my-10 md:my-0 px-16 max-lg:mx-auto">
+      <div className="rounded-2xl w-full h-full flex flex-col gap-4">
         <h2 className="text-lg font-semibold mb-4">대시보드</h2>
-        <div className="w-full flex gap-4 flex-col md:flex-row">
+        <div className="w-full flex gap-4 flex-col lg:flex-row">
           <div className="flex-1 border dark:border-gray-800 rounded-2xl">
             <RecentToDo />
           </div>

--- a/slid-todo/src/app/(routes)/goals/[goalId]/components/goal-list-content.tsx
+++ b/slid-todo/src/app/(routes)/goals/[goalId]/components/goal-list-content.tsx
@@ -9,13 +9,14 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useCreateTodo } from "@/hooks/todo/use-todo-actions";
 import { useFormModal } from "@/stores/use-form-modal-store";
+import { Loading } from "@/components/shared/loading";
 const GoalListContent = () => {
   const { goalId } = useParams();
   const { ref: todoRef, inView: todoInView } = useInView();
   const { ref: doneRef, inView: doneInView } = useInView();
   const { onOpen: onOpenFormModal } = useFormModal();
   const { mutate: createTodo } = useCreateTodo();
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useGoalTodosInfinite(
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useGoalTodosInfinite(
     Number(goalId),
     false,
   );
@@ -25,7 +26,6 @@ const GoalListContent = () => {
     fetchNextPage: fetchDoneNextPage,
     hasNextPage: hasDoneNextPage,
     isFetchingNextPage: isFetchingDoneNextPage,
-    status: doneStatus,
   } = useGoalTodosInfinite(Number(goalId), true);
 
   useEffect(() => {
@@ -42,7 +42,7 @@ const GoalListContent = () => {
 
   const todos = data?.pages.flatMap((page) => page.todos) || [];
   const doneTodos = doneData?.pages.flatMap((page) => page.todos) || [];
-  if (status === "pending" || doneStatus === "pending") {
+  if (isLoading || isFetchingDoneNextPage || isFetchingNextPage) {
     return null;
   }
   const handleOpenFormModal = () => {
@@ -69,6 +69,7 @@ const GoalListContent = () => {
           <h2>Todo</h2>
           <Button
             variant="default"
+            data-testid="add-todo-button"
             className="bg-transparent text-blue-600 dark:text-slate-400 text-sm hover:bg-transparent hover:text-blue-600 dark:hover:text-slate-200 p-0 transition-colors"
             onClick={handleOpenFormModal}
           >

--- a/slid-todo/src/app/(routes)/notes/create/[todoId]/page.tsx
+++ b/slid-todo/src/app/(routes)/notes/create/[todoId]/page.tsx
@@ -52,23 +52,25 @@ const NoteCreatePage = () => {
 
     const data = JSON.parse(preData);
 
-    if (note && note.title === data.title) return;
+    if (note && note.title === data.title && note.content === data.content) return;
 
     setNote(data);
 
-    openConfirm({
-      title: `'${data.title}' 제목의 노트를 불러오시겠습니까?`,
-      confirmText: "불러오기",
-      variant: "info",
-      onConfirm: () => {
-        form.reset({
-          todoId: Number(todoId),
-          title: data.title,
-          content: data.content,
-          linkUrl: data.linkUrl,
-        });
-      },
-    });
+    if (data.title || data.content) {
+      openConfirm({
+        title: `${data.title ? `'${data.title}' 제목의 ` : ""}저장된 노트를 불러오시겠습니까?`,
+        confirmText: "불러오기",
+        variant: "info",
+        onConfirm: () => {
+          form.reset({
+            todoId: Number(todoId),
+            title: data.title,
+            content: data.content,
+            linkUrl: data.linkUrl,
+          });
+        },
+      });
+    }
   }, [todoId, form]);
 
   const handlePreSave = () => {

--- a/slid-todo/src/app/globals.css
+++ b/slid-todo/src/app/globals.css
@@ -121,3 +121,22 @@
 .tiptap {
   padding-left: 0 !important;
 }
+
+@font-face {
+  font-family: "Pretendard-ExtraBold";
+  src: url("/fonts/Pretendard-ExtraBold.subset.woff2") format("woff2");
+  font-weight: 800;
+  font-style: normal;
+}
+
+.ProseMirror strong {
+  font-family:
+    "Pretendard-ExtraBold",
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    sans-serif;
+  letter-spacing: -0.02em;
+}

--- a/slid-todo/src/components/shared/app-sidebar/components/app-sidebar-footer.tsx
+++ b/slid-todo/src/components/shared/app-sidebar/components/app-sidebar-footer.tsx
@@ -14,6 +14,11 @@ export const AppSidebarFooter = () => {
     onOpenFormModal({
       type: "goal",
       mode: "create",
+      defaultValues: {
+        id: 0,
+        title: "",
+        description: "",
+      },
       onSubmit: (data) => {
         createGoal(data);
       },

--- a/slid-todo/src/components/shared/app-sidebar/components/app-sidebar-user-info.tsx
+++ b/slid-todo/src/components/shared/app-sidebar/components/app-sidebar-user-info.tsx
@@ -39,6 +39,11 @@ const AppSidebarUserInfo = () => {
     onOpenFormModal({
       type: "todo",
       mode: "create",
+      defaultValues: {
+        id: 0,
+        title: "",
+        description: "",
+      },
       onSubmit: (data) => {
         createTodo(data);
       },

--- a/slid-todo/src/components/shared/form-modal/components/title-field.tsx
+++ b/slid-todo/src/components/shared/form-modal/components/title-field.tsx
@@ -20,7 +20,11 @@ export const TitleField = ({ type }: TitleFieldProps) => {
           <FormControl>
             <Input
               {...field}
-              placeholder={type === "goal" ? "목표 제목을 입력하세요" : "할 일을 입력하세요"}
+              placeholder={
+                type === "goal"
+                  ? "목표 제목을 입력해주세요."
+                  : "할 일의 제목을 30자 이내로 입력해주세요."
+              }
               className={`text-lg font-medium ${
                 type !== "goal" ? "border-none px-0 placeholder:text-muted-foreground/30" : ""
               }`}

--- a/slid-todo/src/hooks/goals/use-goal.ts
+++ b/slid-todo/src/hooks/goals/use-goal.ts
@@ -54,7 +54,6 @@ export const useGoal = (goalId: number) => {
         return result;
       } catch (error: any) {
         if (error.response?.status === 404) {
-          toast.error("존재하지 않는 목표입니다.");
           router.push("/");
           throw new Error("목표를 찾을 수 없습니다.");
         }


### PR DESCRIPTION
유저 피드백 반영
1. 목표가 생성되어 있지 않은 상태에서 할 일 생성은 그대로 유지하기로 결정 <-- api 필수 값도 아니고 todo만 이용하고 싶은 사람도 있을 수 있다.
2. 목표를 삭제했을 때 "존재하지 않는 목표입니다"가 같이 뜨는 현상 수정
3. 새 목표에서 텍스트 작성 후에 저장하지 않고 모달을 끄는 경우 다시 키면 내용이 인풋에 그대로 남아있는 현상 수정
4. 새 목표에서 작성 후에 저장하지 않고 할 일 생성 모달을 틀었을 시 타이틀에 그대로 내용 전달되는 현상 수정
5. 할 일을 몇 자 이내로 적을 수 있는지 플레이스 홀더 추가
6. 대시보드 좌우 스크롤 생기는 문제 해결
7. 노트에서 볼드체 적용할 시 눈에 띄게 수정 (폰트 변경)
8. 데스크탑 사이즈에서 모바일 사이즈로 너비를 줄일 때 대시보드 우측이 화면 밖으로 나가는 현상 수정
9. 대시보드에 아무 내용이 없을 때 y 스크롤 제거
10. 노트 불러오기가 타이틀만 검증하고 있어 내용도 같이 검증하도록 추가